### PR TITLE
Introduce viewport meta tag and fix content selectability

### DIFF
--- a/_includes/featured_item.html
+++ b/_includes/featured_item.html
@@ -11,7 +11,7 @@
 
   <div class="modal fade" id="featured-modal-content-{{ item.id }}" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
     <div class="modal-dialog">
-      <div class="unselectable modal-content">
+      <div class="modal-content">
         <button class="btn pull-right" id="close-modal" data-dismiss="modal" aria-hidden="true"><i class="glyphicon glyphicon-remove-circle"></i></button>
         <div class="modal-header">
           <img src="{{ item.image }}" class="col-md-6" alt="Lorem Ipsum">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -26,6 +26,9 @@
     <!-- Bootstrap JS -->
     <script src="assets/bootstrap/js/bootstrap.min.js"></script>
 
+    <!-- viewport meta tag -->
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
     <!-- Custom stuff -->
     <link href="assets/css/stylesheet.css" rel="stylesheet">
     <link href="assets/css/custom.css" rel="stylesheet">
@@ -37,7 +40,7 @@
 
   {% include menu.html %}
 
-  <section class="clearfix unselectable" id="content">
+  <section class="clearfix" id="content">
     {{ content }}
   </section><!-- /content -->
 


### PR DESCRIPTION
This commit enables the possibility of content selection and also introduces the viewport meta tag in order to get a more organized mobile version of the site.
It solves a part of the issues discussed here [#19](https://github.com/rosedu/cdl/issues/19).
