### PR TITLE
Updated planning for CDL summer 2026

### DIFF
--- a/_data/form/2026-summer.yml
+++ b/_data/form/2026-summer.yml
@@ -8,5 +8,5 @@
 #
 - title: Formular de înscriere
   content: Te așteptăm să te înscrii la noua ediție de CDL!
-  url: https://forms.gle/HUotEscqmmebFcuP7
+  url: https://forms.gle/34RRJGdcK4ymn7kBA
   url_title: Înscrie-te!

--- a/_data/grids/2026-summer.yml
+++ b/_data/grids/2026-summer.yml
@@ -8,7 +8,7 @@
 - title: "Informații generale"
   content: "CDL este un curs/laborator alternativ, cu o durată de 9 săptămâni, dedicat tuturor celor interesați de software și open source.
     Dacă vreți să fiți contributori și membri în comunități, dacă vă interesează să participați la Google Summer of Code, sau dacă pur și simplu doriți să fiți programatori (mai) buni, CDL este pentru voi.
-    Pentru înscriere trebuie să aveți creat un cont GitHub, cu cel puțin două proiecte (oricât de simple, în două limbaje de programare diferite) și să completați formularul de înscriere până <b>joi, 18 iunie 2026, ora 23:00</b>."
+    Pentru înscriere trebuie să aveți creat un cont GitHub, cu cel puțin două proiecte (oricât de simple, în două limbaje de programare diferite) și să completați formularul de înscriere până <b>sâmbătă, 20 iunie 2026, ora 23:00</b>."
   extra_info: "Cursul este gratuit și accesibil tuturor celor interesați, în limita locurilor disponibile."
 
 - title: "Misiune"

--- a/_includes/2026-summer/planning.html
+++ b/_includes/2026-summer/planning.html
@@ -4,9 +4,9 @@
     <h1 class="section-title"> Program </h1>
     <p>Marți, 23 iunie 2026, 09-12: Controlul versiunilor folosind Git</p>
     <p>Joi, 25 iunie 2026, 09-12: Dezvoltare colaborativă cu GitHub</p>
-    <p>Sâmbătă, 27 iunie 2026, 10-13: Formatul Markdown</p>
-    <p>Marți, 30 iunie 2026, 09-12: Medii de lucru, dezvoltare și deployment cu Docker</p>
-    <p>Joi, 2 iulie 2026, 09-12: Bune practici în inginerie</p>
+    <p>Sâmbătă, 27 iunie 2026, 10-13: Tehnici avansate de GitHub</p>
+    <p>Marți, 30 iunie 2026, 09-12: Formatul Markdown</p>
+    <p>Joi, 2 iulie 2026, 09-12: Medii de lucru, dezvoltare și deployment cu Docker</p>
     <p>Sâmbătă, 4 iulie 2026, 10-13: Hackathon: Lucru la proiect open source</p>
     <p>Marți, 7 iulie 2026, 09-12: Hackathon: Lucru la proiect open source</p>
     <p>Joi, 9 iulie 2026, 09-12: Hackathon: Lucru la proiect open source</p>


### PR DESCRIPTION
- Replaced "Best practices" session with "Advanced Github"

- Updated form responses due date